### PR TITLE
Add explicit docker restart when apply iptables rules

### DIFF
--- a/playbooks/configuration/run-iptables.yml
+++ b/playbooks/configuration/run-iptables.yml
@@ -10,3 +10,14 @@
 
   roles:
     - { role: sorrowless.iptables, tags: ['iptables'] }
+
+  tasks:
+    - name: Restart docker
+      systemd:
+        name: docker
+        state: restarted
+      when:
+        - (iptables.flush_all is defined and iptables.flush_all) or (not iptables.flush_all is defined and iptables_defaults.flush_all)
+      tags:
+        - iptables
+      failed_when: false


### PR DESCRIPTION
Ensure that docker is restarted when iptables roles restarts netfilter. Other way it will break docker DNAT rules, thus remove network reachability from host to containers.