### PR TITLE
Ensure vars to be specified on playbook start

### DIFF
--- a/playbooks/run-backup-reporter.yml
+++ b/playbooks/run-backup-reporter.yml
@@ -5,43 +5,55 @@
 # > ./run-backup-reporter.yml
 ---
 - name: Install and configure backup reporter
-  hosts: backup_reporter
+  hosts: backup_reporters, backup_collectors
   remote_user: root
   tasks:
-    - name: Ensure config directory 
-      file:
+    - name: Ensure variables
+      ansible.builtin.set_fact:
+        backup_reporter_config_dir: "{{ backup_reporter_config_dir | default('/etc/backup-reporter') }}"
+        backup_reporter_google_spreadsheet_credentials: "{{ backup_reporter_google_spreadsheet_credentials | default('') }}"
+        backup_reporter_docker_postgres: "{{ backup_reporter_docker_postgres | default(False) }}"
+        backup_reporter_container_name: "{{ backup_reporter_container_name | default('None') }}"
+        backup_reporter_collector: "{{ backup_reporter_collector | default(False) }}"
+        backup_reporter_sheet_owner: "{{ backup_reporter_sheet_owner | default('None') }}"
+        backup_reporter_spreadsheet_name: "{{ backup_reporter_spreadsheet_name | default('None') }}"
+        backup_reporter_worksheet_name: "{{ backup_reporter_worksheet_name | default('None') }}"
+        backup_reporter_bucket: "{{ backup_reporter_bucket | default('[]') }}"
+
+    - name: Ensure config directory
+      ansible.builtin.file:
         path: "{{ backup_reporter_config_dir }}"
         state: directory
-        mode: '0744'
+        mode: '0755'
 
     - name: Ensure pip is installed
-      package:
+      ansible.builtin.package:
         name:
-         - python3-pip
-         - python3-venv
-         - python3-virtualenv
+          - python3-pip
+          - python3-venv
+          - python3-virtualenv
         state: present
 
     - name: Ensure pip3 is latest version and required packages installed
-      pip:
+      ansible.builtin.pip:
         executable: pip3
         name: pip
         state: latest
-    
+
     - name: Ensure virtualenv
-      shell:
+      ansible.builtin.shell:
         cmd: python3 -m venv backup_reporter
       args:
-        chdir: "{{ backup_reporter_config_dir }}"
-        creates: "{{ backup_reporter_config_dir }}/backup_reporter"
+        chdir: "/opt"
+        creates: "/opt/backup_reporter"
 
     - name: Ensure backup-reporter python package
-      pip:
-        virtualenv: "{{ backup_reporter_config_dir }}/backup_reporter"
+      ansible.builtin.pip:
+        virtualenv: "/opt/backup_reporter"
         name: backup-reporter
 
-    - name: set google credentials json
-      copy:
+    - name: Set google credentials json
+      ansible.builtin.copy:
         dest: "{{ backup_reporter_config_dir }}/google_creds.yml"
         content: "{{ backup_reporter_google_spreadsheet_credentials }}"
         mode: '0700'
@@ -49,21 +61,21 @@
       when: backup_reporter_google_spreadsheet_credentials is defined
 
     - name: Set config file
-      copy:
+      ansible.builtin.copy:
         dest: "{{ backup_reporter_config_dir }}/backup_reporter_config.yml"
         content: |
-          docker_postgres: {{ backup_reporter_docker_postgres | default(False)  }} 
-          container_name: {{ backup_reporter_container_name | default('None')  }}
+          docker_postgres: {{ backup_reporter_docker_postgres }}
+          container_name: {{ backup_reporter_container_name }}
 
-          collector: {{ backup_reporter_collector | default(False) }}
+          collector: {{ backup_reporter_collector }}
 
-          sheet_owner: {{ backup_reporter_sheet_owner | default('None')  }}
-          google_spreadsheet_credentials_path: {{ backup_reporter_google_spreadsheet_credentials_path.dest | default('None')  }}
-          spreadsheet_name: {{ backup_reporter_spreadsheet_name | default('None')  }}
-          worksheet_name: {{ backup_reporter_worksheet_name | default('None')  }}
+          sheet_owner: {{ backup_reporter_sheet_owner }}
+          google_spreadsheet_credentials_path: {{ backup_reporter_config_dir }}/google_creds.yml
+          spreadsheet_name: {{ backup_reporter_spreadsheet_name }}
+          worksheet_name: {{ backup_reporter_worksheet_name }}
 
-          bucket: 
-          {{ backup_reporter_bucket | default('{}') | to_nice_yaml }}
+          bucket:
+          {{ backup_reporter_bucket | to_nice_yaml }}
         mode: '0700'
 
     - name: Set daily cron-job with reporter
@@ -71,4 +83,4 @@
         name: "Backup report"
         minute: "0"
         hour: "1"
-        job: "{{ backup_reporter_config_dir }}/backup_reporter/bin/backup-reporter --config {{ backup_reporter_config_dir }}/backup_reporter_config.yml"
+        job: "/opt/backup_reporter/bin/backup-reporter --config {{ backup_reporter_config_dir }}/backup_reporter_config.yml"


### PR DESCRIPTION
To easily understand which vars needs to be specified in group/host vars, move them explicitly to the top of the playbook.

Also fix linting problems.